### PR TITLE
Fix tagging issue

### DIFF
--- a/player.js
+++ b/player.js
@@ -70,6 +70,8 @@ function onGstMessage(message) {
             let tmp = tagList.get_string('title').toString();
             if (tmp.match('true')) {
                 tag = tmp.slice(5);
+            } else {
+                tag = "";
             }
             break;
         case Gst.MessageType.ERROR:


### PR DESCRIPTION
If a channel which not include a title tag in the stream is played after a channel which correctly updates the title, the old title tag will persist.

Try adding the Russian Radio Maximum (stream: http://maximum.fmtuner.ru) and play that stream _after_ a stream known to include the correct title tag. When switching to Radio Maximum, the old title will show after a while.

The issues is fixed by resetting the tag variable.