### PR TITLE
Support for cyrillic tags encoded in windows-1251, koi8-r or koi8-u

### DIFF
--- a/addChannelDialog.js
+++ b/addChannelDialog.js
@@ -102,7 +102,7 @@ const AddChannelDialog = new Lang.Class({
     _createChannel: function () {
         let inputName = this._nameEntry.get_text();
         let inputStream = this._getStreamAddress(this._addressEntry.get_text());
-        let newChannel = new Channel.Channel(inputName, inputStream, false);
+        let newChannel = new Channel.Channel(inputName, inputStream, false, false);
         if (oldChannel != null) {
             if (oldChannel.getFavourite()){
                 newChannel.setFavourite(oldChannel.getFavourite());

--- a/channel.js
+++ b/channel.js
@@ -4,10 +4,11 @@ const Lang = imports.lang;
 const Channel = new Lang.Class({
     Name: 'Channel',
 
-    _init: function (name, uri, favourite) {
+    _init: function (name, uri, favourite, encoding) {
         this._name = name;
         this._uri = uri;
         this._favourite = favourite;
+        this._encoding = encoding;
     },
 
     setName: function (name) {
@@ -22,6 +23,10 @@ const Channel = new Lang.Class({
         this._favourite = favourite;
     },
 
+    setEncoding: function (encoding) {
+        this._encoding = encoding;
+    },
+
     getName: function () {
         return this._name;
     },
@@ -32,5 +37,13 @@ const Channel = new Lang.Class({
 
     getFavourite: function () {
         return this._favourite;
+    },
+
+    getEncoding: function () {
+        if(typeof this._encoding === 'string') {
+            return this._encoding.toLowerCase();
+        } else {
+            return this._encoding;
+        }
     }
 });

--- a/convertCharset.js
+++ b/convertCharset.js
@@ -1,0 +1,61 @@
+/**
+ * Convert encoding to unicode
+ *
+ * Supported charsets: windows-1251 koi8-r koi8-u
+ * source: http://xpoint.ru/know-how/JavaScript/PoleznyieFunktsii?38#PerekodirovkaIzWindows1251IKOI
+*/
+function convertToUnicode(enc, str) {
+    let res = "";
+    let charmap;
+    let code2char;
+
+    switch (enc) {
+        case "windows-1251":
+            charmap =
+                "%u0402%u0403%u201A%u0453%u201E%u2026%u2020%u2021%u20AC%u2030%u0409%u2039%u040A%u040C%u040B%u040F"+
+                "%u0452%u2018%u2019%u201C%u201D%u2022%u2013%u2014%u0000%u2122%u0459%u203A%u045A%u045C%u045B%u045F"+
+                "%u00A0%u040E%u045E%u0408%u00A4%u0490%u00A6%u00A7%u0401%u00A9%u0404%u00AB%u00AC%u00AD%u00AE%u0407"+
+                "%u00B0%u00B1%u0406%u0456%u0491%u00B5%u00B6%u00B7%u0451%u2116%u0454%u00BB%u0458%u0405%u0455%u0457";
+            code2char = function(code) {
+                if(code >= 0xC0 && code <= 0xFF) return String.fromCharCode(code - 0xC0 + 0x0410);
+                if(code >= 0x80 && code <= 0xBF) return charmap.charAt(code - 0x80);
+                return String.fromCharCode(code);
+            }
+            break;
+        case "koi8-r":
+            charmap =
+                "%u2500%u2502%u250C%u2510%u2514%u2518%u251C%u2524%u252C%u2534%u253C%u2580%u2584%u2588%u258C%u2590"+
+                "%u2591%u2592%u2593%u2320%u25A0%u2219%u221A%u2248%u2264%u2265%u00A0%u2321%u00B0%u00B2%u00B7%u00F7"+
+                "%u2550%u2551%u2552%u0451%u2553%u2554%u2555%u2556%u2557%u2558%u2559%u255A%u255B%u255C%u255D%u255E"+
+                "%u255F%u2560%u2561%u0401%u2562%u2563%u2564%u2565%u2566%u2567%u2568%u2569%u256A%u256B%u256C%u00A9"+
+                "%u044E%u0430%u0431%u0446%u0434%u0435%u0444%u0433%u0445%u0438%u0439%u043A%u043B%u043C%u043D%u043E"+
+                "%u043F%u044F%u0440%u0441%u0442%u0443%u0436%u0432%u044C%u044B%u0437%u0448%u044D%u0449%u0447%u044A"+
+                "%u042E%u0410%u0411%u0426%u0414%u0415%u0424%u0413%u0425%u0418%u0419%u041A%u041B%u041C%u041D%u041E"+
+                "%u041F%u042F%u0420%u0421%u0422%u0423%u0416%u0412%u042C%u042B%u0417%u0428%u042D%u0429%u0427%u042A";
+            code2char = function(code) {
+                if(code >= 0x80 && code <= 0xFF) return charmap.charAt(code - 0x80)
+                return String.fromCharCode(code)
+            }
+            break;
+        case "koi8-u":
+            charmap =
+                "%u2500%u2502%u250C%u2510%u2514%u2518%u251C%u2524%u252C%u2534%u253C%u2580%u2584%u2588%u258C%u2590"+
+                "%u2591%u2592%u2593%u2320%u25A0%u2219%u221A%u2248%u2264%u2265%u00A0%u2321%u00B0%u00B2%u00B7%u00F7"+
+                "%u2550%u2551%u2552%u0451%u0454%u2554%u0456%u0457%u2557%u2558%u2559%u255A%u255B%u0491%u255D%u255E"+
+                "%u255F%u2560%u2561%u0401%u0404%u2563%u0406%u0407%u2566%u2567%u2568%u2569%u256A%u0490%u256C%u00A9"+
+                "%u044E%u0430%u0431%u0446%u0434%u0435%u0444%u0433%u0445%u0438%u0439%u043A%u043B%u043C%u043D%u043E"+
+                "%u043F%u044F%u0440%u0441%u0442%u0443%u0436%u0432%u044C%u044B%u0437%u0448%u044D%u0449%u0447%u044A"+
+                "%u042E%u0410%u0411%u0426%u0414%u0415%u0424%u0413%u0425%u0418%u0419%u041A%u041B%u041C%u041D%u041E"+
+                "%u041F%u042F%u0420%u0421%u0422%u0423%u0416%u0412%u042C%u042B%u0417%u0428%u042D%u0429%u0427%u042A";
+            code2char = function(code) {
+                if(code >= 0x80 && code <= 0xFF) return charmap.charAt(code - 0x80)
+                return String.fromCharCode(code)
+            }
+            break;
+        default:
+            return str;
+            break;
+    }
+    for(let i = 0; i < str.length; i++) res = res + code2char(str.charCodeAt(i));
+    return res;
+}

--- a/extension.js
+++ b/extension.js
@@ -56,7 +56,7 @@ const RadioMenuButton = new Lang.Class({
         this.lastPlayed = this.channelList.lastplayed;
 
         // init last played channel
-        this.lastPlayedChannel = new Channel.Channel(this.lastPlayed.name, this.lastPlayed.address, false);
+        this.lastPlayedChannel = new Channel.Channel(this.lastPlayed.name, this.lastPlayed.address, false, this.lastPlayed.encoding);
 
         // init player
         this.player = new Player.Player(this.lastPlayedChannel);
@@ -201,7 +201,7 @@ const RadioMenuButton = new Lang.Class({
     // init channel and add channels to the PopupMenu
     _initChannels: function (chas) {
         for (var i in chas) {
-            let channel = new Channel.Channel(chas[i].name, chas[i].address, chas[i].favourite);
+            let channel = new Channel.Channel(chas[i].name, chas[i].address, chas[i].favourite, chas[i].encoding);
             this.helperChannelList[i] = channel;
             if (chas[i].favourite) {
                 this._addToFavourites(channel);

--- a/io.js
+++ b/io.js
@@ -39,7 +39,8 @@ function write(channels, lastPlayed) {
 			Shell.write_string_to_stream(out, JSON.stringify({
 				name: channels[i].getName(),
 				address: channels[i].getUri(),
-				favourite: channels[i].getFavourite()
+				favourite: channels[i].getFavourite(),
+				encoding: channels[i].getEncoding()
 			}, null, "\t"));
 			// remove last comma
 			if (i != channels.length - 1) {
@@ -50,7 +51,8 @@ function write(channels, lastPlayed) {
 		Shell.write_string_to_stream(out, "\n],\n\n  \"lastplayed\":");
 		Shell.write_string_to_stream(out, JSON.stringify({
 			name: lastPlayed.getName(),
-			address: lastPlayed.getUri()
+			address: lastPlayed.getUri(),
+			encoding: lastPlayed.getEncoding()
 		}, null, "\t"));
 		Shell.write_string_to_stream(out, "\n}");
 		out.close(null);

--- a/player.js
+++ b/player.js
@@ -10,6 +10,7 @@ const Mainloop = imports.mainloop;
 const Extension = imports.misc.extensionUtils.getCurrentExtension();
 const Channel = Extension.imports.channel;
 const MyE = Extension.imports.extension;
+const Convert = Extension.imports.convertCharset;
 
 Gst.init(null, 0);
 
@@ -69,7 +70,20 @@ function onGstMessage(message) {
             let tagList = message.parse_tag();
             let tmp = tagList.get_string('title').toString();
             if (tmp.match('true')) {
-                tag = tmp.slice(5);
+                switch (getCurrentChannel().getEncoding()) {
+                    case "windows-1251":
+                        tag = Convert.convertToUnicode("windows-1251", tmp.slice(5));
+                        break;
+                    case "koi8-r":
+                        tag = Convert.convertToUnicode("koi8-r", tmp.slice(5));
+                        break;
+                    case "koi8-u":
+                        tag = Convert.convertToUnicode("koi8-u", tmp.slice(5));
+                        break;
+                     default:
+                        tag = tmp.slice(5);
+                        break;
+                }
             } else {
                 tag = "";
             }


### PR DESCRIPTION
With this an extra encoding element is added to each new added station in channelList.json
Currently as an "expert option", the encoding element must be manually changed in channelList.json
The tag will then be converted to unicode before being displayed in the tag label.

Currently supported encodings:
windows-1251 (Russian, Bulgarian, Serbian Cyrillic, Macedonian)
koi8-r (Russian)
koi8-u (Ukrainian)

#### Example

> Channel: 101.ru DDT
> Website: http://101.ru/?an=port_channel_mp3&channel=112
> Stream address: http://ic3.101.ru:8000/c13_21
> channelList.json: "encoding": "windows-1251"

For passing through without any encoding, the encoding element can be omitted or set to false:
"encoding": false

Note, that if an encoding element is added to a station which also appears as "lastplayed" the
encoding element must be set both places.

Additionally, Gnome Shell must be reloaded after changing channelList.json
Alt+F2 => r