### PR TITLE
Charset field in channel dialog

### DIFF
--- a/radio@hslbck.gmail.com/addChannelDialog.js
+++ b/radio@hslbck.gmail.com/addChannelDialog.js
@@ -125,12 +125,11 @@ const AddChannelDialog = new Lang.Class({
     _createChannel: function () {
         let inputName = this._nameEntry.get_text();
         let inputStream = getStreamAddress(this._addressEntry.get_text());
-        let inputCharset = null;
+        let inputCharset = false;
         if (this._charsetEntry.get_text() !== "") {
             inputCharset = Convert.validate(this._charsetEntry.get_text());
-        } else {
-            inputCharset = false;
         }
+        log("RADIO: "+inputCharset);
         let newChannel = new Channel.Channel(inputName, inputStream, false, inputCharset);
         if (oldChannel != null) {
             if (oldChannel.getFavourite()){

--- a/radio@hslbck.gmail.com/addChannelDialog.js
+++ b/radio@hslbck.gmail.com/addChannelDialog.js
@@ -6,6 +6,7 @@ const ShellEntry = imports.ui.shellEntry;
 const Extension = imports.misc.extensionUtils.getCurrentExtension();
 const Channel = Extension.imports.channel;
 const MyE = Extension.imports.extension;
+const Convert = Extension.imports.convertCharset;
 
 // translation support
 const Gettext = imports.gettext.domain("radio@hslbck.gmail.com");
@@ -69,6 +70,25 @@ const AddChannelDialog = new Lang.Class({
             y_align: St.Align.START
         });
 
+        // entry for optional tag text charset conversion
+        let charset = new St.Label({
+            style_class: 'run-dialog-label',
+            text: _("Charset (optional)")
+        });
+        this.contentLayout.add(charset, {
+            y_align: St.Align.START
+        });
+        this._charsetEntry = new St.Entry({
+            style_class: 'run-dialog-entry',
+            can_focus: true
+        });
+        ShellEntry.addContextMenu(this._charsetEntry);
+        this._charsetEntry.label_actor = charset;
+        this._charsetEntryText = this._charsetEntry.clutter_text;
+        this.contentLayout.add(this._charsetEntry, {
+            y_align: St.Align.START
+        });
+
         // set values when editing a channel
         this._setTextValues();
 
@@ -95,6 +115,9 @@ const AddChannelDialog = new Lang.Class({
         if (oldChannel != null) {
             this._nameEntry.set_text(oldChannel.getName());
             this._addressEntry.set_text(oldChannel.getUri());
+            if(oldChannel.getEncoding() !== false) {
+                this._charsetEntry.set_text(oldChannel.getEncoding());
+            }
         }
     },
 
@@ -102,7 +125,13 @@ const AddChannelDialog = new Lang.Class({
     _createChannel: function () {
         let inputName = this._nameEntry.get_text();
         let inputStream = getStreamAddress(this._addressEntry.get_text());
-        let newChannel = new Channel.Channel(inputName, inputStream, false, false);
+        let inputCharset = null;
+        if (this._charsetEntry.get_text() !== "") {
+            inputCharset = Convert.validate(this._charsetEntry.get_text());
+        } else {
+            inputCharset = false;
+        }
+        let newChannel = new Channel.Channel(inputName, inputStream, false, inputCharset);
         if (oldChannel != null) {
             if (oldChannel.getFavourite()){
                 newChannel.setFavourite(oldChannel.getFavourite());

--- a/radio@hslbck.gmail.com/addChannelDialog.js
+++ b/radio@hslbck.gmail.com/addChannelDialog.js
@@ -129,7 +129,6 @@ const AddChannelDialog = new Lang.Class({
         if (this._charsetEntry.get_text() !== "") {
             inputCharset = Convert.validate(this._charsetEntry.get_text());
         }
-        log("RADIO: "+inputCharset);
         let newChannel = new Channel.Channel(inputName, inputStream, false, inputCharset);
         if (oldChannel != null) {
             if (oldChannel.getFavourite()){

--- a/radio@hslbck.gmail.com/channel.js
+++ b/radio@hslbck.gmail.com/channel.js
@@ -40,6 +40,10 @@ const Channel = new Lang.Class({
     },
 
     getEncoding: function () {
+        if(typeof this._encoding === 'undefined') {
+            this.setEncoding(false);
+        }
+
         if(typeof this._encoding === 'string') {
             return this._encoding.toLowerCase();
         } else {

--- a/radio@hslbck.gmail.com/convertCharset.js
+++ b/radio@hslbck.gmail.com/convertCharset.js
@@ -59,3 +59,10 @@ function convertToUnicode(enc, str) {
     for(let i = 0; i < str.length; i++) res = res + code2char(str.charCodeAt(i));
     return res;
 }
+
+function validate(input){
+if(~["windows-1251", "windows1251", "1251"].indexOf(input)) return "windows-1251";
+if(~["koi8-r", "koi8r", "ru"].indexOf(input)) return "koi8-r";
+if(~["koi8-u", "koi8u", "ua"].indexOf(input)) return "koi8-u";
+return false;
+}

--- a/radio@hslbck.gmail.com/po/da.po
+++ b/radio@hslbck.gmail.com/po/da.po
@@ -7,15 +7,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-18 22:31+0200\n"
-"PO-Revision-Date: 2016-09-18 22:32+0200\n"
+"POT-Creation-Date: 2016-12-26 16:45+0100\n"
+"PO-Revision-Date: 2016-12-26 16:45+0100\n"
 "Last-Translator: Niels Rune Brandt <nielsrune@hotmail.com>\n"
 "Language-Team: \n"
 "Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.8.8\n"
+"X-Generator: Poedit 1.8.11\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: addChannelDialog.js:37
@@ -26,11 +26,15 @@ msgstr "Kanalnavn"
 msgid "Stream Address"
 msgstr "Streamadresse"
 
-#: addChannelDialog.js:80 channelListDialog.js:89 searchDialog.js:102
+#: addChannelDialog.js:75
+msgid "Charset (optional)"
+msgstr "Tegnsæt (valgfrit)"
+
+#: addChannelDialog.js:99 channelListDialog.js:89 searchDialog.js:103
 msgid "Cancel"
 msgstr "Annullér"
 
-#: addChannelDialog.js:85 searchDialog.js:108
+#: addChannelDialog.js:104 searchDialog.js:109
 msgid "Add"
 msgstr "Tilføj"
 
@@ -54,11 +58,11 @@ msgstr "Redigér"
 msgid "Play"
 msgstr "Afspil"
 
-#: extension.js:132
+#: extension.js:134
 msgid "Favourites"
 msgstr "Favoritter"
 
-#: extension.js:138
+#: extension.js:140
 msgid "Channels"
 msgstr "Kanaler"
 
@@ -70,23 +74,23 @@ msgstr "Vis notifikationer"
 msgid "Enable Play/Stop Media Keys"
 msgstr "Aktiver multimedieknapper"
 
-#: searchDialog.js:41
+#: searchDialog.js:42
 msgid "Browse "
 msgstr "Gennemse"
 
-#: searchDialog.js:62
+#: searchDialog.js:63
 msgid "Search"
 msgstr "Søg"
 
-#: searchDialog.js:143
+#: searchDialog.js:146
 msgid "No radio station found!"
 msgstr "Ingen radiostationer fundet!"
 
-#: searchDialog.js:146
+#: searchDialog.js:149
 msgid "Server returned status code"
 msgstr "Serveren returnerede statuskode"
 
-#: searchDialog.js:151
+#: searchDialog.js:154
 msgid "Search input was empty!"
 msgstr "Søgeparameter var tom!"
 

--- a/radio@hslbck.gmail.com/po/radio@hslbck.gmail.com.pot
+++ b/radio@hslbck.gmail.com/po/radio@hslbck.gmail.com.pot
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-13 17:52+0200\n"
+"POT-Creation-Date: 2016-12-26 16:45+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.8.9\n"
+"X-Generator: Poedit 1.8.11\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-SearchPath-0: .\n"
 
@@ -27,11 +27,15 @@ msgstr ""
 msgid "Stream Address"
 msgstr ""
 
-#: addChannelDialog.js:80 channelListDialog.js:89 searchDialog.js:102
+#: addChannelDialog.js:75
+msgid "Charset (optional)"
+msgstr ""
+
+#: addChannelDialog.js:99 channelListDialog.js:89 searchDialog.js:103
 msgid "Cancel"
 msgstr ""
 
-#: addChannelDialog.js:85 searchDialog.js:108
+#: addChannelDialog.js:104 searchDialog.js:109
 msgid "Add"
 msgstr ""
 
@@ -55,11 +59,11 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: extension.js:132
+#: extension.js:134
 msgid "Favourites"
 msgstr ""
 
-#: extension.js:138
+#: extension.js:140
 msgid "Channels"
 msgstr ""
 
@@ -71,22 +75,22 @@ msgstr ""
 msgid "Enable Play/Stop Media Keys"
 msgstr ""
 
-#: searchDialog.js:41
+#: searchDialog.js:42
 msgid "Browse "
 msgstr ""
 
-#: searchDialog.js:62
+#: searchDialog.js:63
 msgid "Search"
 msgstr ""
 
-#: searchDialog.js:143
+#: searchDialog.js:146
 msgid "No radio station found!"
 msgstr ""
 
-#: searchDialog.js:146
+#: searchDialog.js:149
 msgid "Server returned status code"
 msgstr ""
 
-#: searchDialog.js:151
+#: searchDialog.js:154
 msgid "Search input was empty!"
 msgstr ""


### PR DESCRIPTION
Implemented an optional entry field for tag charset conversion.
Months ago I tried putting a combobox style submenu in the dialog, but it kept failing.
(The Gnome extension language is terribly documented, imho).

Charset conversion legend:

windows-1251 - enter: **windows-1251**, **windows1251** or **1251**
koi8-r		- enter: **koi8-r**, **koi8r** or **ru**
koi8-u		- enter: **koi8-u**, **koi8u** or **ua**

Entering anything else (or nothing) will equal false, and thus utf-8.
