### PR TITLE
Update readme (charset support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,25 @@ You'll need the `glib-compile-schemas` and `msgfmt` commands on your system, ava
 * Manage radio station list
 * Mark stations as favourites
 * Middle click to start/stop last played station
-* Cyrillic tag support (nielsrune): Usage description in pull request comment https://github.com/hslbck/gnome-shell-extension-radio/pull/18
+* Cyrillic tag support (nielsrune): See below
 * Support for multimedia keys
   * Play / Stop
   * Next / Prev cycles through the channels list (X4lldux)
 * Support for title notification
 * Search online radio directory http://www.radio-browser.info/ (https://github.com/hslbck/gnome-shell-extension-radio/issues/23)
+
+### Charset convertion
+Radio station streams may include tags (track artist and title).
+
+If tags are not served in UTF-8 encoding, non-latin characters may be printed as garbage characters and must be converted to UTF-8 to make sense.
+
+A specific source charset can optionally be set upon adding or editing each channel.
+Unfortunately, older charsets cannot be reliably determined automatically. Finding the right source charset for a channel's tags are therefore a matter of guessing (or guessing again). A tool like https://2cyr.com/decode/ may come useful.
+
+Currently, this extension supports conversion of the following charsets:
+* **windows-1251** (Russian, Bulgarian, Serbian Cyrillic, Macedonian)
+* **koi8-r** (Russian)
+* **koi8-u** (Ukrainian)
 
 ### Translation
 * Open your source folder

--- a/radio@hslbck.gmail.com/addChannelDialog.js
+++ b/radio@hslbck.gmail.com/addChannelDialog.js
@@ -127,7 +127,7 @@ const AddChannelDialog = new Lang.Class({
         let inputStream = getStreamAddress(this._addressEntry.get_text());
         let inputCharset = false;
         if (this._charsetEntry.get_text() !== "") {
-            inputCharset = Convert.validate(this._charsetEntry.get_text());
+            inputCharset = Convert.validate(this._charsetEntry.get_text().toLowerCase());
         }
         let newChannel = new Channel.Channel(inputName, inputStream, false, inputCharset);
         if (oldChannel != null) {

--- a/radio@hslbck.gmail.com/po/de.po
+++ b/radio@hslbck.gmail.com/po/de.po
@@ -7,15 +7,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-25 21:47+0100\n"
-"PO-Revision-Date: 2016-09-13 17:53+0200\n"
+"POT-Creation-Date: 2016-12-29 10:18+0100\n"
+"PO-Revision-Date: 2016-12-29 10:18+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.8.9\n"
+"X-Generator: Poedit 1.8.11\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: prefs.js:40
@@ -34,7 +34,7 @@ msgstr "Senderliste"
 msgid "Manage your radio stations"
 msgstr "Verwalten sie hier ihre Senderliste"
 
-#: channelListDialog.js:89 addChannelDialog.js:80 searchDialog.js:103
+#: channelListDialog.js:89 addChannelDialog.js:100 searchDialog.js:103
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -50,15 +50,19 @@ msgstr "Editieren"
 msgid "Play"
 msgstr "Abspielen"
 
-#: addChannelDialog.js:37
+#: addChannelDialog.js:38
 msgid "Channel Name"
 msgstr "Sendername"
 
-#: addChannelDialog.js:56
+#: addChannelDialog.js:57
 msgid "Stream Address"
 msgstr "Stream Adresse"
 
-#: addChannelDialog.js:85 searchDialog.js:109
+#: addChannelDialog.js:76
+msgid "Charset (optional)"
+msgstr "Charset (optional)"
+
+#: addChannelDialog.js:105 searchDialog.js:109
 msgid "Add"
 msgstr "Hinzufügen"
 


### PR DESCRIPTION
Ref: #42 
Updated readme regarding how to set another charset for the title tags.

Charsets (other than the UTF-kinds) cannot be determined reliably. I there did some testing for the stations on my list, that required it.
I guess one could ask the maintainer of radio-browser.info to add a charset field in the database, but every station would need a manual tag analysis to update charset info if needed.
Maybe the tag could be logged to help users.

I agree that a selection box would be much better. But I simply can't get the popupSubMenu to show in the addChannelDialog. The lack of good documentation is very frustrating. I may give it another go, but it would be in the not-so-near future.
