### PR TITLE
Define 'source' via var instead of let

### DIFF
--- a/radio@hslbck.gmail.com/player.js
+++ b/radio@hslbck.gmail.com/player.js
@@ -25,7 +25,7 @@ Gst.init(null);
 let tag = "";
 let currentChannel;
 let pipeline;
-let source;
+var source;
 let sourceBus;
 let sourceBusId;
 let settings;


### PR DESCRIPTION
In GNOME 3.26 the volume slider stops working after being used once, a line in system log is produced:

> Oct 09 18:22:28 sabretooth gnome-shell[1435]: Some code accessed the property 'source' on the module 'player'. That property was defined with 'let' or 'const' inside the module. This was previously supported, but is not correct according to the ES6 standard. Any symbols to be exported from a module must be defined with 'var'. The property access will work as previously for the time being, but please fix your code  anyway.

You might need  [js38-debug](https://wiki.archlinux.org/index.php/GNOME/Troubleshooting#Shell_segfaults) installed to see this warning.
Changing source to be defined via var fixes the problem and as far i can tell makes slider work as expected.
