### PR TITLE
Fix settings button in gnome 3.36

### DIFF
--- a/radio@hslbck.gmail.com/radioMenu.js
+++ b/radio@hslbck.gmail.com/radioMenu.js
@@ -675,7 +675,7 @@ let RadioMenuButton = GObject.registerClass (
 
     _openPrefs() {
         let _appSys = Shell.AppSystem.get_default();
-        let _gsmPrefs = _appSys.lookup_app('gnome-shell-extension-prefs.desktop');
+        let _gsmPrefs = _appSys.lookup_app('org.gnome.Extensions.desktop');
 
         if (_gsmPrefs.get_state() == _gsmPrefs.SHELL_APP_STATE_RUNNING) {
             _gsmPrefs.activate();


### PR DESCRIPTION
Gnome 3.36 changed gnome-shell-extension-prefs.desktop to org.gnome.Extensions.desktop
This breaks backwards compatibility.