### PR TITLE
Fix titleMenu being not null after "Show title notification in the pa…

### DIFF
--- a/radio@hslbck.gmail.com/titleMenu.js
+++ b/radio@hslbck.gmail.com/titleMenu.js
@@ -48,6 +48,7 @@ function addToPanel() {
 function removeFromPanel() {
     if (titleMenu != null) {
         titleMenu.destroy();
+        titleMenu = null;
     }
 }
 


### PR DESCRIPTION
If you toggle "Show title notification in the panel" on and off the titleMenu gets destroyed yet for some reason its still not null, thus the check in updateTitle() fails and system log is spammed with:
````
Mar 16 12:02:42 sabretooth gnome-shell[1253]: Object .Gjs_radio_hslbck_gmail_com_titleMenu_TitleMenuButton (0x55ef831a7c70), has been already deallocated — impossible to access it. This might be caused by the object having been destroyed from C code using something such as destroy(), dispose(), or remove() vfuncs.
Mar 16 12:02:42 sabretooth gnome-shell[1253]: == Stack trace for context 0x55ef828018e0 ==
Mar 16 12:02:42 sabretooth gnome-shell[1253]: #0   55ef841efd60 i   /home/junaru/.local/share/gnome-shell/extensions/radio@hslbck.gmail.com/titleMenu.js:50 (2b83ed0f08f8 @ 29)
Mar 16 12:02:42 sabretooth gnome-shell[1253]: #1   55ef841efcc8 i   /home/junaru/.local/share/gnome-shell/extensions/radio@hslbck.gmail.com/radioMenu.js:352 (2b83ed0dc088 @ 84)
Mar 16 12:02:42 sabretooth gnome-shell[1253]: #2   55ef841efc38 i   /home/junaru/.local/share/gnome-shell/extensions/radio@hslbck.gmail.com/radioMenu.js:315 (2b83ed0cde20 @ 62)
Mar 16 12:02:42 sabretooth gnome-shell[1253]: #3   7fffed81c780 b   self-hosted:1005 (336267a9c808 @ 454)
Mar 16 12:02:42 sabretooth gnome-shell[1253]: clutter_actor_destroy: assertion 'CLUTTER_IS_ACTOR (self)' failed
````
Not sure if this is correct fix but it works.