### PR TITLE
Fix icon size in default gnome-shell theme

### DIFF
--- a/radio@hslbck.gmail.com/radioMenu.js
+++ b/radio@hslbck.gmail.com/radioMenu.js
@@ -126,10 +126,12 @@ let RadioMenuButton = GObject.registerClass (
 
         // Play and Stop Button Images
         this.playIcon = new St.Icon({
-            icon_name: 'media-playback-start-symbolic'
+            icon_name: 'media-playback-start-symbolic',
+            style_class: 'popup-menu-icon'
         });
         this.stopIcon = new St.Icon({
-            icon_name: 'media-playback-stop-symbolic'
+            icon_name: 'media-playback-stop-symbolic',
+            style_class: 'popup-menu-icon'
         });
 
         // Play - Stop Button
@@ -516,7 +518,8 @@ let RadioMenuButton = GObject.registerClass (
 
     _buildMenuItemButtons() {
         this.settingsIcon = new St.Icon({
-            icon_name: 'preferences-system-symbolic'
+            icon_name: 'preferences-system-symbolic',
+            style_class: 'popup-menu-icon'
         });
         this.settingsButton = new St.Button({
             style_class: 'system-menu-action',
@@ -529,7 +532,8 @@ let RadioMenuButton = GObject.registerClass (
         });
 
         this.channelListIcon = new St.Icon({
-            icon_name: 'view-list-symbolic'
+            icon_name: 'view-list-symbolic',
+            style_class: 'popup-menu-icon'
         });
         this.channelListButton = new St.Button({
             style_class: 'system-menu-action',
@@ -543,7 +547,8 @@ let RadioMenuButton = GObject.registerClass (
         });
 
         this.addChannelIcon = new St.Icon({
-            icon_name: 'list-add-symbolic'
+            icon_name: 'list-add-symbolic',
+            style_class: 'popup-menu-icon'
         });
         this.addChannelButton = new St.Button({
             style_class: 'system-menu-action',
@@ -557,7 +562,8 @@ let RadioMenuButton = GObject.registerClass (
         });
 
         this.searchIcon = new St.Icon({
-            icon_name: 'system-search-symbolic'
+            icon_name: 'system-search-symbolic',
+            style_class: 'popup-menu-icon'
         });
         this.searchButton = new St.Button({
             style_class: 'system-menu-action',


### PR DESCRIPTION
This adds missing icon style for default gnome-shell theme in 3.36. Doesn't look like it changes anything for other themes. Fixes #149 
![comp](https://user-images.githubusercontent.com/59161/81510333-9a468600-9319-11ea-89dd-df3afd89c89d.jpg)
