### PR TITLE
search api changed hostname

### DIFF
--- a/radio@hslbck.gmail.com/searchDialog.js
+++ b/radio@hslbck.gmail.com/searchDialog.js
@@ -144,9 +144,8 @@ var SearchDialog = GObject.registerClass(
         let input = this._searchEntry.get_text();
         this._itemBox.remove_all_children();
         if (input != null && input.trim().length > 0) {
-            // todo: choose random ip from DNS:
-            //    $ dig all.api.radio-browser.info A +noall +answer
-            let url = "http://95.179.139.106/json/stations/byname/" + input
+            // todo: choose random ip from DNS: `$ dig all.api.radio-browser.info A +noall +answer`
+            let url = "http://all.api.radio-browser.info/json/stations/byname/" + input
             var message = Soup.Message.new('POST', url);
             var postParams = 'name=' + input + '&limit=15';
             message.set_request('application/x-www-form-urlencoded', Soup.MemoryUse.COPY, postParams);

--- a/radio@hslbck.gmail.com/searchDialog.js
+++ b/radio@hslbck.gmail.com/searchDialog.js
@@ -144,7 +144,9 @@ var SearchDialog = GObject.registerClass(
         let input = this._searchEntry.get_text();
         this._itemBox.remove_all_children();
         if (input != null && input.trim().length > 0) {
-            let url = "http://www.radio-browser.info/webservice/json/stations/search"
+            // todo: choose random ip from DNS:
+            //    $ dig all.api.radio-browser.info A +noall +answer
+            let url = "http://95.179.139.106/json/stations/byname/" + input
             var message = Soup.Message.new('POST', url);
             var postParams = 'name=' + input + '&limit=15';
             message.set_request('application/x-www-form-urlencoded', Soup.MemoryUse.COPY, postParams);


### PR DESCRIPTION
updated search API to fixed ip address. this is not permanent solution as servers can go down.

a better solution would be to randomly select from a list of active IPs. This can be done using DNS.

I don't know much about gnome shell extensions, but the command I used to get a list of addresses was:
```bash
$ dig all.api.radio-browser.info A +noall +answer
```
hope this is of some use. tested on ubuntu 20.04

[screenshot of successful search results]
![delwedd](https://user-images.githubusercontent.com/1466013/95209076-d7884480-07e1-11eb-901a-83ea1609fe62.png)
