### PR TITLE
Support for Gnome 44

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A GNOME Shell extension for listening to internet radio streams.
 
 ### Features
 
-* Supports GNOME Shell 43 - for older versions see [releases]
+* Supports GNOME Shell 43 and 44 - for older versions see [releases]
 * Manage internet radio streams
 * Middle click to start/stop last played station
 * Cyrillic tag support - see [charset conversion]

--- a/radio@hslbck.gmail.com/metadata.json
+++ b/radio@hslbck.gmail.com/metadata.json
@@ -1,5 +1,5 @@
 {
-	"shell-version": ["43"],
+	"shell-version": ["43","44"],
 	"uuid": "radio@hslbck.gmail.com",
 	"name": "Internet Radio",
 	"description": "Listen to an Internet Radio Stream",


### PR DESCRIPTION
Modified metadata.json and README.md . Working Fedora 38 Beta with Gnome 44. Radio is playing. Searching and adding station works.