### PR TITLE
Add Gnome 44 to supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A GNOME Shell extension for listening to internet radio streams.
 
 ### Features
 
-* Supports GNOME Shell 43 - for older versions see [releases]
+* Supports GNOME Shell 44 - for older versions see [releases]
 * Manage internet radio streams
 * Middle click to start/stop last played station
 * Cyrillic tag support - see [charset conversion]

--- a/radio@hslbck.gmail.com/metadata.json
+++ b/radio@hslbck.gmail.com/metadata.json
@@ -1,5 +1,5 @@
 {
-	"shell-version": ["43"],
+	"shell-version": ["43", "44"],
 	"uuid": "radio@hslbck.gmail.com",
 	"name": "Internet Radio",
 	"description": "Listen to an Internet Radio Stream",


### PR DESCRIPTION
- The current code also works with Gnome 44
- Add this to metadata.json

Signed-off-by:	Johannes Meixner <xmj@chaot.net>
Sponsored-by:	Meixner GmbH